### PR TITLE
Ignore X Spaces containers in overflow fallback

### DIFF
--- a/backend/actions.py
+++ b/backend/actions.py
@@ -211,12 +211,12 @@ def _open_overflow(page) -> bool:
     except Exception:
         pass
 
-    # 3) Global fallback: any "More" button not in sidebar/live pill
+    # 3) Global fallback: any "More" button not in sidebar/live/space widgets
     try:
         ok = page.evaluate(
             """
             () => {
-              const isBad = (el) => el.closest('[data-testid="sidebarColumn"]') || el.closest('[data-testid="pill-contents-container"]');
+              const isBad = (el) => el.closest('[data-testid="sidebarColumn"], [data-testid="pill-contents-container"], [data-testid="placementTracking"]');
               const byAria = Array.from(document.querySelectorAll('button[role="button"][aria-label]'));
               for (const b of byAria) {
                 const label = (b.getAttribute('aria-label')||'').toLowerCase();

--- a/backend/app/actions.py
+++ b/backend/app/actions.py
@@ -107,12 +107,12 @@ def _open_overflow(page) -> bool:
     except Exception:
         pass
 
-    # 3) Global fallback: any "More" button not in sidebar/live pill
+    # 3) Global fallback: any "More" button not in sidebar/live/space widgets
     try:
         ok = page.evaluate(
             """
             () => {
-              const isBad = (el) => el.closest('[data-testid="sidebarColumn"]') || el.closest('[data-testid="pill-contents-container"]');
+              const isBad = (el) => el.closest('[data-testid="sidebarColumn"], [data-testid="pill-contents-container"], [data-testid="placementTracking"]');
               const byAria = Array.from(document.querySelectorAll('button[role="button"][aria-label]'));
               for (const b of byAria) {
                 const label = (b.getAttribute('aria-label')||'').toLowerCase();


### PR DESCRIPTION
## Summary
- Extend overflow-menu fallback to skip elements inside X Spaces containers
- Update comment on fallback selector logic in backend modules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b616f1fe508328a8693617c5717072