### PR TITLE
Fix scraper and classifier reliability

### DIFF
--- a/backend/app/api.py
+++ b/backend/app/api.py
@@ -149,7 +149,7 @@ async def api_search_stream(
         yield _sse_pack("status", {"message": "extracted", "count": len(profiles)})
         yield _sse_pack("profiles", [p.model_dump() for p in profiles])
         if classify and profiles:
-            yield _sse_pack("status", {"message": "classifying"})
+            yield _sse_pack("status", {"message": "classifying", "total": len(profiles)})
             overrides = {}
             if llm_provider:
                 overrides["provider"] = llm_provider
@@ -159,10 +159,25 @@ async def api_search_stream(
                 overrides["model"] = llm_model
             if openai_api_key:
                 overrides["api_key"] = openai_api_key
-            classes = await classify_profiles(profiles, overrides=overrides)
-            for c in classes:
-                save_classification(c)
-            yield _sse_pack("classification", [c.model_dump() for c in classes])
+
+            # chunked classification
+            chunk_size = 25
+            all_classes: List[Classification] = []
+            for i in range(0, len(profiles), chunk_size):
+                chunk = profiles[i:i+chunk_size]
+                try:
+                    yield _sse_pack("status", {"message": "classifying_chunk", "offset": i, "count": len(chunk)})
+                    chunk_classes = await classify_profiles(chunk, overrides=overrides)
+                    for c in chunk_classes:
+                        save_classification(c)
+                    all_classes.extend(chunk_classes)
+                    yield _sse_pack("classification_chunk", [c.model_dump() for c in chunk_classes])
+                    # adaptive sleep
+                    await asyncio.sleep(1)
+                except Exception as e:
+                    yield _sse_pack("error", {"message": "classification_failed", "offset": i, "detail": str(e)})
+
+            yield _sse_pack("classification", [c.model_dump() for c in all_classes])
         yield _sse_pack("done", {"ok": True})
 
     return StreamingResponse(gen(), media_type="text/event-stream")
@@ -235,7 +250,7 @@ async def api_user_list_stream(
         yield _sse_pack("profiles", [p.model_dump() for p in profiles])
 
         if classify and profiles:
-            yield _sse_pack("status", {"message": "classifying"})
+            yield _sse_pack("status", {"message": "classifying", "total": len(profiles)})
             overrides = {}
             if llm_provider:
                 overrides["provider"] = llm_provider
@@ -245,10 +260,25 @@ async def api_user_list_stream(
                 overrides["model"] = llm_model
             if openai_api_key:
                 overrides["api_key"] = openai_api_key
-            classes = await classify_profiles(profiles, overrides=overrides)
-            for c in classes:
-                save_classification(c)
-            yield _sse_pack("classification", [c.model_dump() for c in classes])
+
+            # chunked classification
+            chunk_size = 25
+            all_classes: List[Classification] = []
+            for i in range(0, len(profiles), chunk_size):
+                chunk = profiles[i:i+chunk_size]
+                try:
+                    yield _sse_pack("status", {"message": "classifying_chunk", "offset": i, "count": len(chunk)})
+                    chunk_classes = await classify_profiles(chunk, overrides=overrides)
+                    for c in chunk_classes:
+                        save_classification(c)
+                    all_classes.extend(chunk_classes)
+                    yield _sse_pack("classification_chunk", [c.model_dump() for c in chunk_classes])
+                    # adaptive sleep
+                    await asyncio.sleep(1)
+                except Exception as e:
+                    yield _sse_pack("error", {"message": "classification_failed", "offset": i, "detail": str(e)})
+
+            yield _sse_pack("classification", [c.model_dump() for c in all_classes])
         yield _sse_pack("done", {"ok": True})
 
     return StreamingResponse(gen(), media_type="text/event-stream")

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -48,8 +48,8 @@ class Settings(BaseSettings):
     # scraping scroll tuning
     scrape_scroll_wait_ms: int = Field(default=950)      # wait after each scroll
     scrape_scroll_step_px: int = Field(default=500)     # how far to scroll each step
-    scrape_scroll_max_iters: int = Field(default=50)    # max scroll attempts per search
-    scrape_scroll_stable_iters: int = Field(default=3)   # stop if no new cells after N steps
+    scrape_scroll_max_iters: int = Field(default=250)    # max scroll attempts per search
+    scrape_scroll_stable_iters: int = Field(default=7)   # stop if no new cells after N steps
 
     # api server bind
     api_host: str = Field(default_factory=lambda: os.getenv("API_HOST", "127.0.0.1"))


### PR DESCRIPTION
This commit addresses two issues:

1. The scraper now waits longer for new content to load before stopping, making it more reliable for long lists of users. This was achieved by increasing `scrape_scroll_stable_iters` and `scrape_scroll_max_iters`.

2. The classification process is now done in batches to prevent timeouts and API errors. This also includes better error handling and progress streaming to the frontend.