### PR TITLE
Exclude 'Who to follow' suggestions from scrapes

### DIFF
--- a/backend/scraper_sync.py
+++ b/backend/scraper_sync.py
@@ -171,6 +171,14 @@ def scrape_search_users_sync(query: str, max_results: int = 40, on_new: Optional
     except PwTimeout:
         profiles = []
     else:
+        try:
+            page.evaluate(
+                """
+                document.querySelectorAll('section[aria-label="Who to follow"], section[aria-label="Timeline: Who to follow"]').forEach(el => el.remove());
+                """
+            )
+        except Exception:
+            pass
         # incrementally collect unique profiles while scrolling (calls on_new as items appear)
         profiles = _collect_profiles_incremental(page, query, max_results=max_results, on_new=on_new)
 
@@ -220,6 +228,14 @@ def scrape_user_list_sync(username: str, list_type: str = "followers", max_resul
     except PwTimeout:
         profiles: List[Profile] = []
     else:
+        try:
+            page.evaluate(
+                """
+                document.querySelectorAll('section[aria-label="Who to follow"], section[aria-label="Timeline: Who to follow"]').forEach(el => el.remove());
+                """
+            )
+        except Exception:
+            pass
         profiles = _collect_profiles_incremental(page, query=f"{segment}:{user}", max_results=max_results, on_new=on_new)
 
     if owned:


### PR DESCRIPTION
## Summary
- Remove sidebar sections labeled "Who to follow" before collecting user cells

## Testing
- `python -m py_compile backend/scraper_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68b749ffd274832896c00ee9ec537459