### PR TITLE
Exclude 'Who to follow' suggestions from scrapes

### DIFF
--- a/backend/scraper_sync.py
+++ b/backend/scraper_sync.py
@@ -8,6 +8,43 @@ from .storage import write_profile_cache, save_dataset_entry, now_iso
 SEARCH_URL = "https://x.com/search?q={q}&src=typed_query&f=user"
 
 
+def _init_strip_suggestions(page):
+    """Remove suggestion sidebars and keep them removed."""
+    try:
+        page.evaluate(
+            """
+            (function() {
+                const remove = () => {
+                    const sel = [
+                        'section[aria-label="Who to follow"]',
+                        'section[aria-label="Timeline: Who to follow"]',
+                        'section[aria-label="You might like"]',
+                        'aside[aria-label="Who to follow"]',
+                        'aside[aria-label="Timeline: Who to follow"]',
+                        'aside[aria-label="You might like"]'
+                    ].join(',');
+                    document.querySelectorAll(sel).forEach(el => el.remove());
+                    try {
+                        const xp = '/html/body/div[1]/div/div/div[2]/main/div/div/div/div[2]/div/div[2]/div/div/div/div[4]/div/aside';
+                        const node = document.evaluate(xp, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+                        if (node) node.remove();
+                    } catch {}
+                };
+                // expose for manual re-use
+                window.__removeSuggestions = remove;
+                remove();
+                if (!window.__removeSuggestionsObserver) {
+                    const obs = new MutationObserver(remove);
+                    obs.observe(document.body, {subtree: true, childList: true});
+                    window.__removeSuggestionsObserver = obs;
+                }
+            })();
+            """
+        )
+    except Exception:
+        pass
+
+
 def _safe_inner_text(locator) -> str | None:
     try:
         return locator.inner_text()
@@ -64,6 +101,10 @@ def _collect_profiles_incremental(page, query: str, max_results: int = 40, on_ne
     last_uniques = 0
 
     for _ in range(max_iters):
+        try:
+            page.evaluate("window.__removeSuggestions && window.__removeSuggestions();")
+        except Exception:
+            pass
         count = cells.count()
         added_step: List[Profile] = []
         # Parse all currently visible cells (windowed list)
@@ -171,6 +212,7 @@ def scrape_search_users_sync(query: str, max_results: int = 40, on_new: Optional
     except PwTimeout:
         profiles = []
     else:
+        _init_strip_suggestions(page)
         # incrementally collect unique profiles while scrolling (calls on_new as items appear)
         profiles = _collect_profiles_incremental(page, query, max_results=max_results, on_new=on_new)
 
@@ -220,6 +262,7 @@ def scrape_user_list_sync(username: str, list_type: str = "followers", max_resul
     except PwTimeout:
         profiles: List[Profile] = []
     else:
+        _init_strip_suggestions(page)
         profiles = _collect_profiles_incremental(page, query=f"{segment}:{user}", max_results=max_results, on_new=on_new)
 
     if owned:


### PR DESCRIPTION
## Summary
- Install mutation observer to delete "Who to follow" and "You might like" sidebars and keep them removed
- Invoke cleanup before each scraping loop so suggestion accounts never slip into results

## Testing
- `python -m py_compile backend/scraper_sync.py`


------
https://chatgpt.com/codex/tasks/task_e_68b749ffd274832896c00ee9ec537459